### PR TITLE
Crash if setting has no value #5

### DIFF
--- a/src/ByteDev.DotNet/Solution/Parsers/DotNetSolutionGlobalSectionParser.cs
+++ b/src/ByteDev.DotNet/Solution/Parsers/DotNetSolutionGlobalSectionParser.cs
@@ -48,7 +48,7 @@ namespace ByteDev.DotNet.Solution.Parsers
             {
                 var nameValue = settingLine.Split(new[] {" = "}, StringSplitOptions.None).ToArray();
 
-                gc.Settings.Add(nameValue[0], nameValue[1]);
+                gc.Settings.Add(nameValue[0], nameValue.Length > 1 ? nameValue[1] : "");
             }
 
             return gc;


### PR DESCRIPTION
Check if the setting has a value. If not, make it an empty string.